### PR TITLE
[WIP]アソシエーションの誤字修正

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -38,9 +38,9 @@
 ## messages table
 |Column|type|options|
 |------|----|-------|
-|body|text||
+|body|text|null: false|
 |image|string||
-|groupu_id|integer|foreign_key: true|
+|group_id|integer|foreign_key: true|
 |user_id|integer|foreign_key: true|
 
 ### Association

--- a/README.rdoc
+++ b/README.rdoc
@@ -6,8 +6,8 @@
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :groups
-- belongs_to :users
+- belongs_to :group
+- belongs_to :user
 
 
 
@@ -43,8 +43,8 @@
 
 
 ### Association
-- belongs_to :users
-- belongs_to :groups
+- belongs_to :user
+- belongs_to :group
 
 
 ## messages table
@@ -56,4 +56,4 @@
 |user_id|integer|foreign_key: true|
 
 ### Association
-- belongs_to: users
+- belongs_to: user

--- a/README.rdoc
+++ b/README.rdoc
@@ -7,7 +7,7 @@
 
 ### Association
 - has_many :messages
-- has_many :groups, through: :usergroups
+- has_many :groups, through: :user_groups
 
 
 
@@ -23,7 +23,7 @@
 - has_many :user_groups
 
 
-## user_group table
+## user_groups table
 |Column|type|options|
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
@@ -44,4 +44,5 @@
 |user_id|integer|foreign_key: true|
 
 ### Association
-- belongs_to: user
+- belongs_to :user
+- belogns_to :group

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,8 +2,8 @@
 |Column|type|options|
 |------|----|-------|
 |user_id|integer|foreign_key: true|
-|name|string|null: false|
-|email|string|null: false|
+|name|string|null: false, unique: true|
+|email|string|null: false, unique: true|
 
 ### Association
 - has_many :messages

--- a/README.rdoc
+++ b/README.rdoc
@@ -1,16 +1,3 @@
-## members table
-
-|Column|type|options|
-|------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :group
-- belongs_to :user
-
-
-
 ## users table
 |Column|type|options|
 |------|----|-------|
@@ -38,8 +25,8 @@
 ## user_group table
 |Column|type|options|
 |------|----|-------|
-|user_id|integer|foreign_key: true|
-|group_id|integer|foreign_key: true|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
 
 ### Association

--- a/README.rdoc
+++ b/README.rdoc
@@ -18,8 +18,9 @@
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many: messages
-- has_many: users, through: :user_groups
+- has_many :messages
+- has_many :users, through: :user_groups
+- has_many :user_groups
 
 
 ## user_group table

--- a/README.rdoc
+++ b/README.rdoc
@@ -8,6 +8,7 @@
 ### Association
 - has_many :messages
 - has_many :groups, through: :user_groups
+- has_many :user_groups
 
 
 


### PR DESCRIPTION
・アソシエーションの誤字を修正：　belongs_to :users => user

・表記の誤りを修正するため