### PR TITLE
メッセージ失敗時のフラッシュ機能実装

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -12,8 +12,11 @@ class MessagesController < ApplicationController
 
   def create
     @message = Message.new(message_params)
-    @message.save
-    redirect_to group_messages_path
+    if @message.save
+      redirect_to group_messages_path
+    else 
+      redirect_to group_messages_path, alert: "メッセージを入力してください"
+    end
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
     if current_user.update(user_params)
-       redirect_to messages_path, notice: "ユーザー情報を編集しました。"
+       redirect_to root_path, notice: "ユーザー情報を編集しました。"
       else
        flash.now[:alert] = "ユーザー情報を正しく入力してください"
        render "edit"

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -23,7 +23,7 @@
       %div.right-messages
         %div.right-messages__top
           %button.right-messages__top--edit_button
-            = link_to "Edit", edit_group_path(current_user)
+            = link_to "Edit", edit_group_path(@group)
 
           %p.right-messages__top--groupname
             = @group.name


### PR DESCRIPTION
what
・メッセージ送信失敗時のフラッシュを実装
・ユーザー編集機能のパス修正
・グループ編集機能のパス修正
why
・メッセージが空で送られるのを防ぐため
・ユーザー、グループ編集機能のパスが正しくなかったため、正しいパスに修正し使用できるようにした